### PR TITLE
Fix menu event handling and quiet macOS warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5231,7 +5231,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -5239,6 +5239,9 @@ name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
 
 [[package]]
 name = "strum_macros"
@@ -5250,6 +5253,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.106",
 ]
 

--- a/crates/tpower/src/provider/remote.rs
+++ b/crates/tpower/src/provider/remote.rs
@@ -30,35 +30,32 @@ pub fn get_device_ioreg(conn: &ServiceConnection) -> Result<IORegistry, DeviceDa
         "EntryClass" = "IOPMPowerSource"
         "Request" = "IORegistry"
     };
-    
+
     // Verify request is valid - use as_concrete_TypeRef which should not be null
     let request_ref = request.as_concrete_TypeRef();
     if request_ref.is_null() {
         return Err(DeviceDataError::NullResponse);
     }
-    
+
     // Send the request
-    unsafe {
-        conn.send(request_ref)
-            .map_err(DeviceDataError::Send)
-    }?;
+    unsafe { conn.send(request_ref).map_err(DeviceDataError::Send) }?;
 
     // Receive the response
     let response_ptr = conn.receive().map_err(DeviceDataError::Receive)?;
-    
+
     // Check if response is null
     if response_ptr.is_null() {
         return Err(DeviceDataError::NullResponse);
     }
-    
+
     let response = unsafe { CFDictionary::wrap_under_create_rule(response_ptr) };
 
     // Parse the response
     let data = dict_into::<repr::IORegistryDiagnostic>(response)?;
-    
+
     // Check diagnostics data validity manually instead of using is_none()
     // We can't directly check if ioregistry is None, so we'll proceed and let other error handling catch issues
-    
+
     // SAFETY: IORegistry and repr::IORegistry are designed to be the same
-    Ok(unsafe { mem::transmute(data.diagnostics.ioregistry) })
+    Ok(unsafe { mem::transmute::<repr::IORegistry, IORegistry>(data.diagnostics.ioregistry) })
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ tauri-specta = { version = "=2.0.0-rc.21", features = [
   "derive",
   "typescript"
 ] }
-strum = "0.27.2"
+strum = { version = "0.27.2", features = ["derive"] }
 objc2 = "0.6.2"
 objc2-app-kit = "0.3.1"
 objc2-foundation = "0.3.1"

--- a/src-tauri/src/local.rs
+++ b/src-tauri/src/local.rs
@@ -64,17 +64,14 @@ pub fn start_sender<R: Runtime>(
 
     let mut timer = time::interval(Duration::from_millis(
         app.pinia()
-            .try_get::<u64>("preference", "updateInterval")
-            .unwrap_or(2000),
+            .get_or("preference", "updateInterval", 2000_u64),
     ));
-    let mut status_bar_item = app
-        .pinia()
-        .try_get::<StatusBarItem>("preference", "statusBarItem")
-        .unwrap_or(StatusBarItem::System);
+    let mut status_bar_item =
+        app.pinia()
+            .get_or("preference", "statusBarItem", StatusBarItem::System);
     let mut show_charging = app
         .pinia()
-        .try_get::<bool>("preference", "showCharging")
-        .unwrap_or(true);
+        .get_or("preference", "showCharging", true);
 
     async_runtime::spawn(async move {
         loop {

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -45,7 +45,7 @@ pub fn setup_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
         ))
         .separator()
         .item(
-            &MenuItemBuilder::with_id(MenuEvent::Preferences, "Preferences")
+            &MenuItemBuilder::with_id(MenuEvent::Preferences.as_ref(), "Preferences")
                 .accelerator("Cmd+,")
                 .build(app)?,
         )

--- a/src-tauri/src/tray_icon.rs
+++ b/src-tauri/src/tray_icon.rs
@@ -23,7 +23,7 @@ pub fn setup_tray_icon<R: Runtime>(app: &impl Manager<R>) -> tauri::Result<()> {
 
     let tray_icon = TrayIconBuilder::with_id("main")
         .title("0 w")
-        .menu_on_left_click(false)
+        .show_menu_on_left_click(false)
         .menu(&menu)
         .build(app)
         .unwrap();

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 // Forked from https://github.com/clearlysid/tauri-plugin-decorum/blob/main/src/lib.rs
 
 use cocoa::{base::nil, foundation::NSString};
@@ -337,26 +339,26 @@ pub fn setup_traffic_light_positioner<R: Runtime>(window: WebviewWindow<R>) {
             app_box: *mut c_void = app_box,
             toolbar: id = cocoa::base::nil,
             super_delegate: id = current_delegate,
-            (windowShouldClose:) => on_window_should_close as extern fn(&Object, Sel, id) -> BOOL,
-            (windowWillClose:) => on_window_will_close as extern fn(&Object, Sel, id),
-            (windowDidResize:) => on_window_did_resize::<R> as extern fn(&Object, Sel, id),
-            (windowDidMove:) => on_window_did_move as extern fn(&Object, Sel, id),
-            (windowDidChangeBackingProperties:) => on_window_did_change_backing_properties as extern fn(&Object, Sel, id),
-            (windowDidBecomeKey:) => on_window_did_become_key as extern fn(&Object, Sel, id),
-            (windowDidResignKey:) => on_window_did_resign_key as extern fn(&Object, Sel, id),
-            (draggingEntered:) => on_dragging_entered as extern fn(&Object, Sel, id) -> BOOL,
-            (prepareForDragOperation:) => on_prepare_for_drag_operation as extern fn(&Object, Sel, id) -> BOOL,
-            (performDragOperation:) => on_perform_drag_operation as extern fn(&Object, Sel, id) -> BOOL,
-            (concludeDragOperation:) => on_conclude_drag_operation as extern fn(&Object, Sel, id),
-            (draggingExited:) => on_dragging_exited as extern fn(&Object, Sel, id),
-            (window:willUseFullScreenPresentationOptions:) => on_window_will_use_full_screen_presentation_options as extern fn(&Object, Sel, id, NSUInteger) -> NSUInteger,
-            (windowDidEnterFullScreen:) => on_window_did_enter_full_screen::<R> as extern fn(&Object, Sel, id),
-            (windowWillEnterFullScreen:) => on_window_will_enter_full_screen::<R> as extern fn(&Object, Sel, id),
-            (windowDidExitFullScreen:) => on_window_did_exit_full_screen::<R> as extern fn(&Object, Sel, id),
-            (windowWillExitFullScreen:) => on_window_will_exit_full_screen::<R> as extern fn(&Object, Sel, id),
-            (windowDidFailToEnterFullScreen:) => on_window_did_fail_to_enter_full_screen as extern fn(&Object, Sel, id),
-            (effectiveAppearanceDidChange:) => on_effective_appearance_did_change::<R> as extern fn(&Object, Sel, id),
-            (effectiveAppearanceDidChangedOnMainThread:) => on_effective_appearance_did_changed_on_main_thread as extern fn(&Object, Sel, id)
+            (windowShouldClose:) => on_window_should_close as extern "C" fn(&Object, Sel, id) -> BOOL,
+            (windowWillClose:) => on_window_will_close as extern "C" fn(&Object, Sel, id),
+            (windowDidResize:) => on_window_did_resize::<R> as extern "C" fn(&Object, Sel, id),
+            (windowDidMove:) => on_window_did_move as extern "C" fn(&Object, Sel, id),
+            (windowDidChangeBackingProperties:) => on_window_did_change_backing_properties as extern "C" fn(&Object, Sel, id),
+            (windowDidBecomeKey:) => on_window_did_become_key as extern "C" fn(&Object, Sel, id),
+            (windowDidResignKey:) => on_window_did_resign_key as extern "C" fn(&Object, Sel, id),
+            (draggingEntered:) => on_dragging_entered as extern "C" fn(&Object, Sel, id) -> BOOL,
+            (prepareForDragOperation:) => on_prepare_for_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL,
+            (performDragOperation:) => on_perform_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL,
+            (concludeDragOperation:) => on_conclude_drag_operation as extern "C" fn(&Object, Sel, id),
+            (draggingExited:) => on_dragging_exited as extern "C" fn(&Object, Sel, id),
+            (window:willUseFullScreenPresentationOptions:) => on_window_will_use_full_screen_presentation_options as extern "C" fn(&Object, Sel, id, NSUInteger) -> NSUInteger,
+            (windowDidEnterFullScreen:) => on_window_did_enter_full_screen::<R> as extern "C" fn(&Object, Sel, id),
+            (windowWillEnterFullScreen:) => on_window_will_enter_full_screen::<R> as extern "C" fn(&Object, Sel, id),
+            (windowDidExitFullScreen:) => on_window_did_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id),
+            (windowWillExitFullScreen:) => on_window_will_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id),
+            (windowDidFailToEnterFullScreen:) => on_window_did_fail_to_enter_full_screen as extern "C" fn(&Object, Sel, id),
+            (effectiveAppearanceDidChange:) => on_effective_appearance_did_change::<R> as extern "C" fn(&Object, Sel, id),
+            (effectiveAppearanceDidChangedOnMainThread:) => on_effective_appearance_did_changed_on_main_thread as extern "C" fn(&Object, Sel, id)
         });
 
         init_listener(delegate);


### PR DESCRIPTION
## Summary
- enable strum's derive macros and use the derived helpers when wiring menu IDs
- migrate Pinia accessors to the new `get_or` API and refresh the tray icon configuration
- annotate the unsafe transmute and quiet macOS delegate warnings with explicit C ABIs

## Testing
- cargo fmt *(emits warnings about nightly-only formatting options)*
- cargo clippy --all-targets --workspace *(fails: missing `glib-2.0` system dependency in container)*
- cargo check -p tpower *(fails: `mach2` crate requires macOS target)*

------
https://chatgpt.com/codex/tasks/task_e_68d37650da88832195cb9646629f7468